### PR TITLE
[LIVE-7258] - Remove from now playing when needed

### DIFF
--- a/Sources/Robin/Robin.swift
+++ b/Sources/Robin/Robin.swift
@@ -276,7 +276,10 @@ extension Robin {
     /// ```
     ///
     /// Calls the `pause()` method on the `player` and updates the Now Playing information.
-    public func pause() {
+    public func pause(removeFromNowPlaying: Bool = false) {
+        if removeFromNowPlaying {
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        }
         self.player.rate = 0.0
         player.pause()
         updateNowPlaying()
@@ -506,6 +509,7 @@ extension Robin: AVAudioPlayerDelegate {
     /// This method takes appropriate actions once the audio playback has finished. It updates the audio state, synchronizes the "Now Playing" information, and if the player is currently set to play a queue of audio sources, it will proceed to play the next track.
     @objc
     private func playerDidFinishPlaying() {
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
         audioObserverStateChanged(state: .finished)
         updateNowPlaying()
         if isPlayingQueue {


### PR DESCRIPTION
When audio finishes playing or when it's closed via the expanded player, the now playing screen should be removed from the Lock Screen.

This PR adds the option to remove from the Lock Screen when paused and ensures it's removed when the audio ends.