### PR TITLE
Update audio session configuration on play/pause

### DIFF
--- a/Sources/Robin/Robin.swift
+++ b/Sources/Robin/Robin.swift
@@ -61,16 +61,25 @@ public class Robin: NSObject, ObservableObject {
 
     /// Configures the audio session with an initial state.
     ///
-    /// The audio session is set with an `ambient` AVAudioSessionCategory to ensure playing videos do not interrupt background audio.
+    /// The audio session is set with an `ambient` AVAudioSessionCategory to ensure the app does not unintentionally interrupt other playback experiences.
     public static func configureAudioSession() throws {
-        try AVAudioSession.sharedInstance().setCategory(.ambient, mode: .moviePlayback)
-        try AVAudioSession.sharedInstance().setActive(true)
+        do {
+            try AVAudioSession.sharedInstance()
+                .setCategory(AVAudioSession.Category.ambient)
+            do {
+                try AVAudioSession.sharedInstance().setActive(true)
+            } catch let error as NSError {
+                print("Robin / " + error.localizedDescription)
+            }
+        } catch let error as NSError {
+            print("Robin / " + error.localizedDescription)
+        }
     }
 
     /// A function used to update the audio session
     /// - Parameter isMuted: A boolean describing an updated `isMuted` status.
     ///
-    /// It is important that we reconfigure the audio session when the mute status changes. For unmuting we want to make sure the audio takes over any background sound, then on mute setting the session back to ambient means background audio won't be interrupted in the case of other sound configuration changes, eg. volume up, silent off.
+    /// It is important that we reconfigure the audio session when the mute status changes. For unmuting we want to make sure the audio takes over any background sound, then on mute setting the session back to ambient to ensure background audio won't be interrupted in the case of other sound configuration changes, eg. volume up, silent off.
     public static func updateAudioSession(isMuted: Bool) throws  {
         let category: AVAudioSession.Category = isMuted ? .ambient : .playback
         let options: AVAudioSession.CategoryOptions = isMuted ? .mixWithOthers : []


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR fixes an issue in which podcast audio would not play again after being paused by a looping video. This was due to looping video setting the audio session category back to "ambient" on mute, which then isn't reset by the podcast audio - resulting in no sound from the podcast audio on resume. 

To fix this problem I have updated the configuration of the shared `AVAudioSession` within the Robin package which to ensure it updates appropriately on playback changes. 
Notably, we configure the audio session to be `ambient` once initially - to ensure that the Robin package does not inadvertently mean that other audio outputs in the app would interrupt background audio. Then because looping videos change the audio session it is important that the Robin package also updates the audio session appropriately on play/pause. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
You can test this by pointing the iOS live app to this branch. 
Play a podcast. 
Scroll down the home front - to the Documentary section where you'll find a looping video. 
Unmute the looping video, observe the podcast pauses. 
Try playing the podcast again, observe it plays audio as expected. 

Without this change, resuming audio on the podcast failed. 
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
