### PR TITLE
Handle Interruptions

### DIFF
--- a/Sources/Robin/Robin.swift
+++ b/Sources/Robin/Robin.swift
@@ -592,7 +592,7 @@ extension Robin {
         case .ended:
             let optionsValue = (info[AVAudioSessionInterruptionOptionKey] as? UInt) ?? 0
             let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
-            do { try AVAudioSession.sharedInstance().setActive(true) } catch { /* log */ }
+            try? AVAudioSession.sharedInstance().setActive(true)
             play()
         @unknown default:
             break

--- a/Sources/Robin/Robin.swift
+++ b/Sources/Robin/Robin.swift
@@ -70,6 +70,14 @@ public class Robin: NSObject, ObservableObject {
                 .setCategory(AVAudioSession.Category.playback)
             do {
                 try AVAudioSession.sharedInstance().setActive(true)
+
+                // Observe any interruptions to audio.
+                NotificationCenter.default.addObserver(
+                    self,
+                    selector: #selector(handleInterruption(_:)),
+                    name: AVAudioSession.interruptionNotification,
+                    object: AVAudioSession.sharedInstance()
+                )
             } catch let error as NSError {
                 print("Robin / " + error.localizedDescription)
             }
@@ -564,6 +572,32 @@ extension Robin: AVAudioPlayerDelegate {
         Task.detached(priority: .high) { @MainActor in
             self.currentState = state
             self.delegate?.didUpdateState(state: state)
+        }
+    }
+}
+
+extension Robin {
+    
+    /// Handles interruption by other audio sources and resumes the playback once the interupption has ended.
+    /// - Parameter note: Notification information.
+    @objc private func handleInterruption(_ note: Notification) {
+        guard
+            let info = note.userInfo,
+            let typeValue = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+            let type = AVAudioSession.InterruptionType(rawValue: typeValue)
+        else { return }
+        switch type {
+        case .began:
+            pause()
+        case .ended:
+            let optionsValue = (info[AVAudioSessionInterruptionOptionKey] as? UInt) ?? 0
+            let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+            do { try AVAudioSession.sharedInstance().setActive(true) } catch { /* log */ }
+            if options.contains(.shouldResume) {
+                play()
+            }
+        @unknown default:
+            break
         }
     }
 }

--- a/Sources/Robin/Robin.swift
+++ b/Sources/Robin/Robin.swift
@@ -592,8 +592,10 @@ extension Robin {
         case .ended:
             let optionsValue = (info[AVAudioSessionInterruptionOptionKey] as? UInt) ?? 0
             let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
-            try? AVAudioSession.sharedInstance().setActive(true)
-            play()
+            if options.contains(.shouldResume) {
+                try? AVAudioSession.sharedInstance().setActive(true)
+                play()
+            }
         @unknown default:
             break
         }

--- a/Sources/Robin/Robin.swift
+++ b/Sources/Robin/Robin.swift
@@ -593,9 +593,7 @@ extension Robin {
             let optionsValue = (info[AVAudioSessionInterruptionOptionKey] as? UInt) ?? 0
             let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
             do { try AVAudioSession.sharedInstance().setActive(true) } catch { /* log */ }
-            if options.contains(.shouldResume) {
-                play()
-            }
+            play()
         @unknown default:
             break
         }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

At the moment, when a podcast is playing and an interruption occurs, the playback doesn't resume. These interruptions can be announcements from the Apple Fitness app or Maps.

This PR handles these interruptions so if an announcement is being made, the playback is paused and resumed after the announcement is completed.

Relevant docs: https://developer.apple.com/documentation/avfaudio/handling-audio-interruptions

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
- I've tested this on a physical device with fitness announcements.
- Enable announcements in workouts
- Start a podcast in the app
- Start a workout
- When an announcement occurs, the playback pauses and resumes once it's finished.

You can alternatively also test this using Maps navigation announcements.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

https://github.com/user-attachments/assets/dd3af517-29e0-41ce-b7f2-a3845ac505cc