### PR TITLE
Ensure Audio session is reconfigured on playback

### DIFF
--- a/Sources/Robin/Robin.swift
+++ b/Sources/Robin/Robin.swift
@@ -67,7 +67,7 @@ public class Robin: NSObject, ObservableObject {
     private func preparePlayer() {
         do {
             try AVAudioSession.sharedInstance()
-                .setCategory(AVAudioSession.Category.playback)
+                .setCategory(AVAudioSession.Category.playback, options: [])
             do {
                 try AVAudioSession.sharedInstance().setActive(true)
 
@@ -104,7 +104,6 @@ extension Robin: RobinAudioCache {
     ///   - audioSounds: The array of `RobinAudioSource` representing the playlist.
     ///   - autostart: A flag indicating whether to start playback automatically upon loading. Default is `true`.
     public func loadPlaylist(audioSounds: [RobinAudioSource], autostart: Bool = true, useCache: Bool = true) {
-        preparePlayer()
         isPlayingQueue = true
         audioQueue = audioSounds
         audioIndex = 0
@@ -270,6 +269,7 @@ extension Robin {
     ///
     /// - Note: You can customize the playback rate by setting the `playbackRate` property before calling this method.
     public func play() {
+        preparePlayer()
         self.player.rate = self.playbackRate
 
         if MPNowPlayingInfoCenter.default().nowPlayingInfo == nil {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Since the iOS live app now has other audio channels, eg. looping video which interacts with the shared AVAudioSession for the app it is important that when a podcast is played it always has the correct configuration. 
This PR ensures that both the category and options are set on `play`. 
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Steps to reproduce original bug:

Start a podcast
Pause
Play audio in some external app
Go to Home front and scroll to a looping video
Play the podcast.

Ensure the podcast takes over from background audio and does not mix. Playback controls should also be visible in the control centre. 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
