### PR TITLE
Remove Notification Observer for Handling Interruptions

### DIFF
--- a/Sources/Robin/Robin.swift
+++ b/Sources/Robin/Robin.swift
@@ -62,7 +62,7 @@ public class Robin: NSObject, ObservableObject {
     override init() {
         super.init()
     }
-    
+
     deinit {
         NotificationCenter.default.removeObserver(
             self,
@@ -70,7 +70,7 @@ public class Robin: NSObject, ObservableObject {
             object: AVAudioSession.sharedInstance()
         )
     }
-    
+
     /// Configures the audio session for playback.
     private func preparePlayer() {
         do {

--- a/Sources/Robin/Robin.swift
+++ b/Sources/Robin/Robin.swift
@@ -63,6 +63,14 @@ public class Robin: NSObject, ObservableObject {
         super.init()
     }
     
+    deinit {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance()
+        )
+    }
+    
     /// Configures the audio session for playback.
     private func preparePlayer() {
         do {

--- a/Sources/Robin/Robin.swift
+++ b/Sources/Robin/Robin.swift
@@ -64,11 +64,7 @@ public class Robin: NSObject, ObservableObject {
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(
-            self,
-            name: AVAudioSession.interruptionNotification,
-            object: AVAudioSession.sharedInstance()
-        )
+        removeInterruptionNotificationObserver()
     }
 
     /// Configures the audio session for playback.
@@ -80,18 +76,32 @@ public class Robin: NSObject, ObservableObject {
                 try AVAudioSession.sharedInstance().setActive(true)
 
                 // Observe any interruptions to audio.
-                NotificationCenter.default.addObserver(
-                    self,
-                    selector: #selector(handleInterruption(_:)),
-                    name: AVAudioSession.interruptionNotification,
-                    object: AVAudioSession.sharedInstance()
-                )
+                addInterruptionNotificationObserver()
             } catch let error as NSError {
                 print("Robin / " + error.localizedDescription)
             }
         } catch let error as NSError {
             print("Robin / " + error.localizedDescription)
         }
+    }
+    
+    /// Adds a notification observer so Robin knows if there has been an audio interruption.
+    func addInterruptionNotificationObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleInterruption(_:)),
+            name: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance()
+        )
+    }
+    
+    /// Removes a notification observer listening to audio interruptions.
+    func removeInterruptionNotificationObserver() {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance()
+        )
     }
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR ensures that the Notification observer for handling interruptions is removed when Robin is deinit.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
